### PR TITLE
Fixed 'repaired vehicle' message

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -22,6 +22,6 @@ AddEventHandler('esx_repairkit:removeKit', function()
 
 	if not Config.InfiniteRepairs then
 		xPlayer.removeInventoryItem('repairkit', 1)
-		TriggerClientEvent(_U('used_kit'))
+		TriggerClientEvent('esx:showNotification', _source, _U('used_kit'))
 	end
 end)


### PR DESCRIPTION
Good work on the script, but you've obviously forgotten to implement the message where the player recives a message saying that they've used a kit, really simple fix and FXServer no longer cries, also kudos for a Swedish translation and correct spacings (others are retarded)

aaaand I'd recommend you to upload the script to the FiveM forums,
Tested and works great.